### PR TITLE
Add BERTSQUADFP16.mlmodel to backend/app/model

### DIFF
--- a/backend/app/model/BERTSQUADFP16.mlmodel
+++ b/backend/app/model/BERTSQUADFP16.mlmodel
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aef4e095d9e6cd78f16f263fec8a8df856b136ed3eba9d5de9908592968ddd50
+size 217826610


### PR DESCRIPTION
This PR adds the BERTSQUADFP16.mlmodel file to the backend/app/model directory. The file is tracked using Git LFS to handle its large size.